### PR TITLE
Add ${workspaceRoot} to default filesToScan config

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
             "properties": {
                 "autoimport.filesToScan": {
                     "type": "string",
-                    "default": "**/*.ts",
+                    "default": "${workspaceRoot}/**/*.ts",
                     "description": "Glob for files to watch and scan, e.g ./src/** ./src/app/**/*.ts. Defaults to **/*.ts"
                 },
                 "autoimport.showNotifications": {


### PR DESCRIPTION
I was having issues with the file I wanted to import (in the same folder as the working file) was not being detected. This seems to have fixed it, and should probably be the default for the extension.