### PR TITLE
Don't add './' if the path already starts with '../'

### DIFF
--- a/src/helpers/path-helper.ts
+++ b/src/helpers/path-helper.ts
@@ -14,7 +14,7 @@ export class PathHelper {
 
             let preAppend = './';
 
-            if (!rp.startsWith(preAppend)) {
+            if (!rp.startsWith(preAppend) && !rp.startsWith('../')) {
                 rp = preAppend + rp;
             }
 


### PR DESCRIPTION
'./../something' is the same as '../something'